### PR TITLE
PROXY-DOMAIN may be a subdomain + domain

### DIFF
--- a/src/node/main.ts
+++ b/src/node/main.ts
@@ -153,7 +153,7 @@ export const runCodeServer = async (
 
   if (args["proxy-domain"].length > 0) {
     logger.info(`  - ${plural(args["proxy-domain"].length, "Proxying the following domain")}:`)
-    args["proxy-domain"].forEach((domain) => logger.info(`    - *.${domain}`))
+    args["proxy-domain"].forEach((domain) => logger.info(`    - ${domain}`))
   }
 
   if (args.link) {


### PR DESCRIPTION
Improvement This logging was confusing when a user passes a full <subdomain>.<domain> as proxy-domain, for instance when running code-server with cloudflare tunnels.
This is likely not the best fix. If preferred, I can do some work here to determine if the string is just a domain, or a subdomain+domain, and switch logging behavior based on that condition.

